### PR TITLE
Fix resume bullet positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,8 @@
         .timeline-item::before {
             content: '';
             position: absolute;
-            left: -9px;
+            /* Position bullet so it aligns with the timeline line */
+            left: -34px;
             top: 5px;
             background-color: var(--accent);
             width: 18px;


### PR DESCRIPTION
## Summary
- ensure the resume timeline dots don't overlap the text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c0da88b388320a541f25b280d20bb