### PR TITLE
Implement project carousel with detail pages

### DIFF
--- a/attensi.html
+++ b/attensi.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Attensi Training Simulations</title>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        body { margin:0; font-family:'Cinzel',serif; background-color:#102121; color:#E8E6E3; line-height:1.6; }
+        .container { max-width:800px; margin:40px auto; padding:0 20px; }
+        a { color:#C8C0A3; }
+        img { max-width:100%; height:auto; display:block; margin-bottom:20px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Attensi Training Simulations</h1>
+        <img src="https://attensi.com/wp-content/uploads/Attensi-BEHAVIOUR-sims-1280x704.png.webp" alt="Attensi Simulation">
+        <p>More information about the Attensi Training Simulations project.</p>
+        <p><a href="index.html#projects">Back to projects</a></p>
+    </div>
+</body>
+</html>

--- a/blipblop.html
+++ b/blipblop.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mosaic: BlipBlop</title>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        body { margin:0; font-family:'Cinzel',serif; background-color:#102121; color:#E8E6E3; line-height:1.6; }
+        .container { max-width:800px; margin:40px auto; padding:0 20px; }
+        a { color:#C8C0A3; }
+        img { max-width:100%; height:auto; display:block; margin-bottom:20px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Mosaic: BlipBlop</h1>
+        <img src="https://images.squarespace-cdn.com/content/v1/5c5c0d4994d71a50652eda86/1558080394431-A5SQRD3DO2XKM2AR25BI/intense.PNG?format=1000w" alt="Mosaic: BlipBlop">
+        <p>More information about Mosaic: BlipBlop.</p>
+        <p><a href="index.html#projects">Back to projects</a></p>
+    </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -149,11 +149,17 @@
             margin-bottom: 20px;
             color: var(--accent);
         }
-        /* Projects Section */
-        .projects-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-            gap: 20px;
+        /* Projects Carousel */
+        .carousel {
+            position: relative;
+            overflow: hidden;
+        }
+        .carousel-track {
+            display: flex;
+            transition: transform 0.5s ease;
+        }
+        .carousel-item {
+            flex: 0 0 100%;
         }
         .project-card {
             background-color: var(--text-dark);
@@ -163,19 +169,16 @@
             transition: transform 0.3s;
             position: relative;
         }
-        .project-card:hover {
-            transform: translateY(-5px);
-        }
         .project-card img {
             width: 100%;
-            height: 200px;
+            height: 300px;
             object-fit: cover;
         }
         .project-content {
             padding: 20px;
+            color: var(--text-light);
             opacity: .8;
             transition: opacity 0.3s;
-            color: var(--text-light);
         }
         .project-card:hover .project-content {
             opacity: 1;
@@ -366,41 +369,51 @@
     </section>
 
     <!-- Projects Section -->
-    <section id="projects">
+        <section id="projects">
         <div class="container">
             <h2>Featured Projects</h2>
-            <div class="projects-grid">
-                <!-- Project 1 -->
-                <div class="project-card">
-                    <img src="https://attensi.com/wp-content/uploads/Attensi-BEHAVIOUR-sims-1280x704.png.webp" alt="Attensi Simulation" /> 
-                    <div class="project-content">
-                        <h3>Attensi Training Simulations</h3>
-                        <p>Developed and designed simulation-based trainings using in-house tools. Collaborated with cross-functional teams to implement interactive scenarios using Unity.</p>
-                    </div>
-                </div>
-                <!-- Project 2 -->
-                <div class="project-card">
-                    <img src="https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1331910/header.jpg?t=1731674476" alt="Mørkredd" /> 
-                    <div class="project-content">
-                        <h3>Mørkredd</h3>
-                        <p>Gameplay programming and network implementation for the atmospheric game "Mørkredd". Focused on creating engaging enemy AI and multiplayer functionality.</p>
-                    </div>
-                </div>
-                <!-- Project 3 -->
-                <div class="project-card">
-                    <img src="https://images.squarespace-cdn.com/content/v1/5c5c0d4994d71a50652eda86/1558080394431-A5SQRD3DO2XKM2AR25BI/intense.PNG?format=1000w" alt="Mosaic: BlipBlop" /> 
-                    <div class="project-content">
-                        <h3>Mosaic: BlipBlop</h3>
-                        <p>Contributed as gameplay programmer and QA for Mosaic: BlipBlop. Designed core mechanics and ensured seamless gameplay experiences.</p>
-                    </div>
-                </div>
-                <!-- Project 4 -->
-                <div class="project-card">
-                    <img src="https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/349270/header.jpg?t=1692101206" alt="Mosaic" /> 
-                    <div class="project-content">
-                        <h3>Mosaic</h3>
-                        <p>QA testing and gameplay enhancements for the puzzle game "Mosaic". Implemented feedback systems to refine game balance and player direction.</p>
-                    </div>
+            <div class="carousel">
+                <div class="carousel-track">
+                    <!-- Project 1 -->
+                    <a href="attensi.html" class="carousel-item">
+                        <div class="project-card">
+                            <img src="https://attensi.com/wp-content/uploads/Attensi-BEHAVIOUR-sims-1280x704.png.webp" alt="Attensi Simulation" />
+                            <div class="project-content">
+                                <h3>Attensi Training Simulations</h3>
+                                <p>Developed and designed simulation-based trainings using in-house tools. Collaborated with cross-functional teams to implement interactive scenarios using Unity.</p>
+                            </div>
+                        </div>
+                    </a>
+                    <!-- Project 2 -->
+                    <a href="morkredd.html" class="carousel-item">
+                        <div class="project-card">
+                            <img src="https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1331910/header.jpg?t=1731674476" alt="Mørkredd" />
+                            <div class="project-content">
+                                <h3>Mørkredd</h3>
+                                <p>Gameplay programming and network implementation for the atmospheric game "Mørkredd". Focused on creating engaging enemy AI and multiplayer functionality.</p>
+                            </div>
+                        </div>
+                    </a>
+                    <!-- Project 3 -->
+                    <a href="blipblop.html" class="carousel-item">
+                        <div class="project-card">
+                            <img src="https://images.squarespace-cdn.com/content/v1/5c5c0d4994d71a50652eda86/1558080394431-A5SQRD3DO2XKM2AR25BI/intense.PNG?format=1000w" alt="Mosaic: BlipBlop" />
+                            <div class="project-content">
+                                <h3>Mosaic: BlipBlop</h3>
+                                <p>Contributed as gameplay programmer and QA for Mosaic: BlipBlop. Designed core mechanics and ensured seamless gameplay experiences.</p>
+                            </div>
+                        </div>
+                    </a>
+                    <!-- Project 4 -->
+                    <a href="mosaic.html" class="carousel-item">
+                        <div class="project-card">
+                            <img src="https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/349270/header.jpg?t=1692101206" alt="Mosaic" />
+                            <div class="project-content">
+                                <h3>Mosaic</h3>
+                                <p>QA testing and gameplay enhancements for the puzzle game "Mosaic". Implemented feedback systems to refine game balance and player direction.</p>
+                            </div>
+                        </div>
+                    </a>
                 </div>
             </div>
         </div>
@@ -499,9 +512,18 @@
                 }
             });
         }, observerOptions);
+
         sections.forEach(section => {
             observer.observe(section);
         });
+
+        // Simple carousel logic
+        const track = document.querySelector('.carousel-track');
+        let currentSlide = 0;
+        setInterval(() => {
+            currentSlide = (currentSlide + 1) % track.children.length;
+            track.style.transform = `translateX(-${currentSlide * 100}%)`;
+        }, 5000);
 
         // Flashlight effect using Three.js
         const flCanvas = document.getElementById('flashlight-canvas');

--- a/morkredd.html
+++ b/morkredd.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mørkredd</title>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        body { margin:0; font-family:'Cinzel',serif; background-color:#102121; color:#E8E6E3; line-height:1.6; }
+        .container { max-width:800px; margin:40px auto; padding:0 20px; }
+        a { color:#C8C0A3; }
+        img { max-width:100%; height:auto; display:block; margin-bottom:20px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Mørkredd</h1>
+        <img src="https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1331910/header.jpg?t=1731674476" alt="Mørkredd">
+        <p>More information about the Mørkredd project.</p>
+        <p><a href="index.html#projects">Back to projects</a></p>
+    </div>
+</body>
+</html>

--- a/mosaic.html
+++ b/mosaic.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mosaic</title>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        body { margin:0; font-family:'Cinzel',serif; background-color:#102121; color:#E8E6E3; line-height:1.6; }
+        .container { max-width:800px; margin:40px auto; padding:0 20px; }
+        a { color:#C8C0A3; }
+        img { max-width:100%; height:auto; display:block; margin-bottom:20px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Mosaic</h1>
+        <img src="https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/349270/header.jpg?t=1692101206" alt="Mosaic">
+        <p>More information about the Mosaic project.</p>
+        <p><a href="index.html#projects">Back to projects</a></p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace grid of project cards with auto-scrolling carousel
- link each project to its own detail page
- create simple pages for Attensi Training Simulations, Mørkredd, Mosaic: BlipBlop and Mosaic
- add basic carousel script

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68554e3ddefc83208e5c1b7ff7818ab3